### PR TITLE
Create package.json to simplify handling dependencies

### DIFF
--- a/app/templates/package.json
+++ b/app/templates/package.json
@@ -1,0 +1,23 @@
+{
+  "version": "0.1.0",
+  "dependencies": {},
+  "scripts": {
+    "start": "gulp",
+    "build": "gulp build"
+  },
+  "devDependencies": {
+    "browser-sync": "^2.10.1",
+    "browserify": "^12.0.1",
+    "coffee-reactify": "^4.0.0",
+    "coffee-script": "^1.10.0",
+    "gulp": "^3.9.0",
+    "gulp-coffee": "^2.3.1",
+    "gulp-size": "^2.0.0",
+    "gulp-sketch": "^0.1.0",
+    "gulp-sourcemaps": "^1.6.0",
+    "gulp-uglify": "^1.5.1",
+    "vinyl-buffer": "^1.0.0",
+    "vinyl-source-stream": "^1.1.0",
+    "watchify": "^3.6.1"
+  }
+}


### PR DESCRIPTION
I've been installing dependencies for ~10 minutes, it would be great if others could get everything they need using _npm install_
